### PR TITLE
Google map

### DIFF
--- a/src/app/Events/FarmCreated.php
+++ b/src/app/Events/FarmCreated.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Farm;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class FarmCreated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public Farm $farm)
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/src/app/Events/ReviewCommentCreated.php
+++ b/src/app/Events/ReviewCommentCreated.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\ReviewComments;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ReviewCommentCreated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public ReviewComments $reviewComments)
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/src/app/Jobs/SendFarmCreatedEmailJob.php
+++ b/src/app/Jobs/SendFarmCreatedEmailJob.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Mail\FarmCreatedMail;
+use App\Models\FarmMailBadge;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Mail;
+use Throwable;
+
+class SendFarmCreatedEmailJob implements ShouldQueue
+{
+    use Queueable, Dispatchable, InteractsWithQueue, SerializesModels;
+
+    public $tries =3;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(public int $badgeId) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $badge = FarmMailBadge::query()->with(['user', 'farm'])->findOrFail($this->badgeId);
+
+        // 冪等：すでに送信済みなら何もしない（再実行されても安全）
+        if ($badge->send_at) {
+            return;
+        }
+
+        Mail::to($badge->user->email)->send(new FarmCreatedMail($badge->farm));
+
+        $badge->update([
+            'send_at'    => now(),
+            'failed_at'  => null,
+            'last_error' => null,
+        ]);
+    }
+
+    public function failed(Throwable $e)
+    {
+        FarmMailBadge::whereKey($this->badgeId)->update([
+            'failed_at'  => now(),
+            'last_error' => $e->getMessage(),
+        ]);
+    }
+}

--- a/src/app/Jobs/SendReviewCreatedEmailJob.php
+++ b/src/app/Jobs/SendReviewCreatedEmailJob.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Mail\ReviewCreateMail;
+use App\Models\ReviewMailBadge;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Throwable;
+
+class SendReviewCreatedEmailJob implements ShouldQueue
+{
+    use Queueable, Dispatchable, InteractsWithQueue, SerializesModels;
+
+    public $tries = 3;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(public int $badgeId)
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $badge = ReviewMailBadge::findOrFail($this->badgeId);
+
+        Log::info('job reached', [
+            'userId' => $badge->user_id,
+            'reviewId' => $badge->review_id,
+        ]);
+
+        if ($badge->sent_at) {
+            return;
+        }
+
+        Mail::to($badge->user->email)->send(new ReviewCreateMail($badge->review));
+
+        $badge->update([
+            'sent_at'    => now(),
+            'failed_at'  => null,
+            'last_error' => null,
+        ]);
+    }
+
+    public function failed(?Throwable $e)
+    {
+        ReviewMailBadge::whereKey($this->badgeId)->update([
+            'failed_at'  => now(),
+            'last_error' => $e->getMessage(),
+        ]);
+    }
+
+}

--- a/src/app/Listeners/CreateFarmMailBadges.php
+++ b/src/app/Listeners/CreateFarmMailBadges.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\FarmCreated;
+use App\Jobs\SendFarmCreatedEmailJob;
+use App\Models\FarmMailBadge;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Log;
+
+class CreateFarmMailBadges
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(FarmCreated $event): void
+    {
+        $farm = $event->farm;
+
+        // 例：通知対象ユーザー（全員なのか、購読者だけなのかは要件次第）
+        $users = User::query()->whereNotNull('email')->get(['id']);
+
+        foreach($users as $user) {
+            $badge = FarmMailBadge::firstOrCreate([
+                'farm_id' => $farm->id,
+                'user_id' => $user->id,
+            ]);
+
+            SendFarmCreatedEmailJob::dispatch($badge->id)->onQueue('mail');
+        }
+    }
+}

--- a/src/app/Listeners/CreateReviewCommentMailBadges.php
+++ b/src/app/Listeners/CreateReviewCommentMailBadges.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\ReviewCommentCreated;
+use App\Jobs\SendReviewCreatedEmailJob;
+use App\Models\ReviewMailBadge;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Log;
+
+class CreateReviewCommentMailBadges
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(ReviewCommentCreated $event): void
+    {
+        $reviewComments = $event->reviewComments;
+
+        Log::info('listener reached', [
+            'comment' => $reviewComments->comment,
+            'userId'  => $reviewComments->review->reviewUser->id,
+            'reviewId' =>  $reviewComments->review->id,
+        ]);
+
+        $userId   = $reviewComments->review->reviewUser->id;
+        $reviewId = $reviewComments->review_id;
+
+        $badge = ReviewMailBadge::firstOrCreate([
+            'user_id'   => $userId,
+            'review_id' => $reviewId
+        ]);
+
+
+        SendReviewCreatedEmailJob::dispatch($badge->id)->onQueue('mail');
+    }
+}

--- a/src/app/Mail/FarmCreatedMail.php
+++ b/src/app/Mail/FarmCreatedMail.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Farm;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class FarmCreatedMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(public Farm $farm)
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: '新しいファームが登録されました',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.farms.created',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/src/app/Mail/ReviewCreateMail.php
+++ b/src/app/Mail/ReviewCreateMail.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Review;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ReviewCreateMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(public Review $review)
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: "{$this->review->name}様へのレビューに対するコメント",
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.reviews.reviewCreated',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/src/app/Models/Farm.php
+++ b/src/app/Models/Farm.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Events\FarmCreated;
+use App\Services\GeocodingService;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -29,6 +30,24 @@ class Farm extends Model
     {
         static::created(function (Farm $farm) {
             event(new FarmCreated($farm));
+        });
+
+        static::saved(function (Farm $farm) {
+            $addressFields = ['street_address', 'suburb', 'state_id', 'postcode'];
+
+            $changed = collect($addressFields)->contains(fn($f) => $farm->wasChanged($f));
+            if (!$changed) return;
+
+            $address = $farm->fullAddress();
+            if (blank($address)) return;
+
+            $geo = app(GeocodingService::class)->geocode($address);
+            if (!$geo) return;
+
+            $farm->forceFill([
+                'latitude'  => $geo['lat'],
+                'longitude' => $geo['lng'],
+            ])->saveQuietly();
         });
     }
 
@@ -90,7 +109,7 @@ class Farm extends Model
      * 住所を1つに繋げる
      * @return string $parts
      */
-    public function fullAddress():string
+    public function fullAddress(): string
     {
         $stateName = $this->state?->name ?? '';
 

--- a/src/app/Models/Farm.php
+++ b/src/app/Models/Farm.php
@@ -85,4 +85,23 @@ class Farm extends Model
     {
         return $this->hasMany(FarmMailBadge::class);
     }
+
+    /**
+     * 住所を1つに繋げる
+     * @return string $parts
+     */
+    public function fullAddress():string
+    {
+        $stateName = $this->state?->name ?? '';
+
+        $parts = array_filter([
+            $this->street_address,
+            $this->suburb,
+            $stateName,
+            $this->postcode,
+            'Australia',
+        ], fn($part) => filled($part));
+
+        return implode(',', $parts);
+    }
 }

--- a/src/app/Models/Farm.php
+++ b/src/app/Models/Farm.php
@@ -26,31 +26,6 @@ class Farm extends Model
         'created_user_id',
     ];
 
-    protected static function booted()
-    {
-        static::created(function (Farm $farm) {
-            event(new FarmCreated($farm));
-        });
-
-        static::saved(function (Farm $farm) {
-            $addressFields = ['street_address', 'suburb', 'state_id', 'postcode'];
-
-            $changed = collect($addressFields)->contains(fn($f) => $farm->wasChanged($f));
-            if (!$changed) return;
-
-            $address = $farm->fullAddress();
-            if (blank($address)) return;
-
-            $geo = app(GeocodingService::class)->geocode($address);
-            if (!$geo) return;
-
-            $farm->forceFill([
-                'latitude'  => $geo['lat'],
-                'longitude' => $geo['lng'],
-            ])->saveQuietly();
-        });
-    }
-
     /**
      * ファーム情報を登録したユーザーを取得
      * @return BelongsTo
@@ -122,5 +97,34 @@ class Farm extends Model
         ], fn($part) => filled($part));
 
         return implode(',', $parts);
+    }
+
+    /**
+     * 新規ファームが登録されたらイベント実行
+     * ファーム住所に変更があったら変更した軽度と緯度の登録
+     */
+    protected static function booted(): void
+    {
+        static::created(function (Farm $farm) {
+            event(new FarmCreated($farm));
+        });
+
+        static::saved(function (Farm $farm) {
+            $addressFields = ['street_address', 'suburb', 'state_id', 'postcode'];
+
+            $changed = collect($addressFields)->contains(fn($f) => $farm->wasChanged($f));
+            if (!$changed) return;
+
+            $address = $farm->fullAddress();
+            if (blank($address)) return;
+
+            $geo = app(GeocodingService::class)->geocode($address);
+            if (!$geo) return;
+
+            $farm->forceFill([
+                'latitude'  => $geo['lat'],
+                'longitude' => $geo['lng'],
+            ])->saveQuietly();
+        });
     }
 }

--- a/src/app/Models/Farm.php
+++ b/src/app/Models/Farm.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Events\FarmCreated;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -23,6 +24,13 @@ class Farm extends Model
         'description',
         'created_user_id',
     ];
+
+    protected static function booted()
+    {
+        static::created(function (Farm $farm) {
+            event(new FarmCreated($farm));
+        });
+    }
 
     /**
      * ファーム情報を登録したユーザーを取得
@@ -67,5 +75,14 @@ class Farm extends Model
     public function images(): HasMany
     {
         return $this->hasMany(FarmImages::class);
+    }
+
+    /**
+     * ファームにもとづく送信結果
+     * @return HasMany
+     */
+    public function farmMailBadges(): HasMany
+    {
+        return $this->hasMany(FarmMailBadge::class);
     }
 }

--- a/src/app/Models/FarmMailBadge.php
+++ b/src/app/Models/FarmMailBadge.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FarmMailBadge extends Model
+{
+    protected $table = 'farm_mail_badges';
+
+    protected $fillable = [
+        'user_id',
+        'farm_id',
+        'send_at',
+        'failed_at',
+        'last_error',
+    ];
+
+    protected $cast = [
+        'send_at'   => 'datetime',
+        'failed_at' => 'datetime,'
+    ];
+
+    /**
+     * 親テーブル
+     * @return BelongsTo
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * 親テーブル
+     * @return BelongsTo
+     */
+    public function farm(): BelongsTo
+    {
+        return $this->belongsTo(Farm::class);
+    }
+}

--- a/src/app/Models/Review.php
+++ b/src/app/Models/Review.php
@@ -75,4 +75,13 @@ class Review extends Model
     {
         return $this->belongsToMany(User::class, 'review_favorites', 'review_id', 'user_id')->withTimestamps();
     }
+
+    /**
+     * レビューに紐づく送信結果
+     * @return HasMany
+     */
+    public function reviewMailBadges(): HasMany
+    {
+        return $this->hasMany(ReviewMailBadge::class);
+    }
 }

--- a/src/app/Models/ReviewMailBadge.php
+++ b/src/app/Models/ReviewMailBadge.php
@@ -2,28 +2,28 @@
 
 namespace App\Models;
 
-use App\Events\ReviewCommentCreated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class ReviewComments extends Model
+class ReviewMailBadge extends Model
 {
+    protected $table= 'review_mail_badges';
+
     protected $fillable = [
-        'review_id',
         'user_id',
-        'comment',
+        'review_id',
+        'sent_at',
+        'failed_at',
+        'last_error',
     ];
 
-        public static function booted()
-    {
-        static::created(function(ReviewComments $reviewComments) {
-            event(new ReviewCommentCreated($reviewComments));
-        });
-    }
-
+    protected $casts = [
+        'sent_at' => 'datetime',
+        'failed_at' => 'datetime',
+    ];
 
     /**
-     * レビューコメントの投稿者を取得
+     * 親テーブル
      * @return BelongsTo
      */
     public function user(): BelongsTo
@@ -32,7 +32,7 @@ class ReviewComments extends Model
     }
 
     /**
-     * レビューコメントが紐づくレビューを取得
+     * 親テーブル
      * @return BelongsTo
      */
     public function review(): BelongsTo

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -6,7 +6,6 @@ namespace App\Models;
 use App\Models\Review;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -86,5 +85,23 @@ class User extends Authenticatable
     public function image(): HasOne
     {
         return $this->hasOne(UserImage::class);
+    }
+
+    /**
+     * ユーザーに紐づく送信結果（ファーム）
+     * @return HasMany
+     */
+    public function farmMailBadges(): HasMany
+    {
+        return $this->hasMany(FarmMailBadge::class);
+    }
+
+    /**
+     * ユーザーに紐づく送信結果（レビュー）
+     * @return HasMany
+     */
+    public function reviewMailBadges(): HasMany
+    {
+        return $this->hasMany(ReviewMailBadge::class);
     }
 }

--- a/src/app/Services/GeocodingService.php
+++ b/src/app/Services/GeocodingService.php
@@ -25,6 +25,6 @@ class GeocodingService
         $loc = $data['results'][0]['geometry']['location'] ?? null;
         if(!$loc) return null;
 
-        return ['lat' => $loc['lat'], 'log' => $loc['log']];
+        return ['lat' => $loc['lat'], 'lng' => $loc['lng']];
     }
 }

--- a/src/app/Services/GeocodingService.php
+++ b/src/app/Services/GeocodingService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class GeocodingService
+{
+    public function geocode(string $address): ?array
+    {
+        $key = config('services.google_maps.key');
+
+        $res = Http::get('https://maps.googleapis.com/maps/api/geocode/json',[
+            'address' => $address,
+            'key'     => $key,
+        ]);
+
+        if (!$res->ok()) {
+            return null;
+        }
+
+        $data = $res->json();
+        if (($data['status'] ?? '') !== 'OK') return null;
+
+        $loc = $data['results'][0]['geometry']['location'] ?? null;
+        if(!$loc) return null;
+
+        return ['lat' => $loc['lat'], 'log' => $loc['log']];
+    }
+}

--- a/src/config/queue.php
+++ b/src/config/queue.php
@@ -40,7 +40,7 @@ return [
             'table' => env('DB_QUEUE_TABLE', 'jobs'),
             'queue' => env('DB_QUEUE', 'default'),
             'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 90),
-            'after_commit' => false,
+            'after_commit' => true,
         ],
 
         'beanstalkd' => [
@@ -49,7 +49,7 @@ return [
             'queue' => env('BEANSTALKD_QUEUE', 'default'),
             'retry_after' => (int) env('BEANSTALKD_QUEUE_RETRY_AFTER', 90),
             'block_for' => 0,
-            'after_commit' => false,
+            'after_commit' => true,
         ],
 
         'sqs' => [
@@ -60,7 +60,7 @@ return [
             'queue' => env('SQS_QUEUE', 'default'),
             'suffix' => env('SQS_SUFFIX'),
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
-            'after_commit' => false,
+            'after_commit' => true,
         ],
 
         'redis' => [
@@ -69,7 +69,7 @@ return [
             'queue' => env('REDIS_QUEUE', 'default'),
             'retry_after' => (int) env('REDIS_QUEUE_RETRY_AFTER', 90),
             'block_for' => null,
-            'after_commit' => false,
+            'after_commit' => true,
         ],
 
     ],

--- a/src/config/services.php
+++ b/src/config/services.php
@@ -35,4 +35,8 @@ return [
         ],
     ],
 
+    'google_maps' => [
+        'key' => env('GOOGLE_MAPS_API_KEY'),
+    ],
+
 ];

--- a/src/database/migrations/2026_01_08_143558_create_farm_mail_badges.php
+++ b/src/database/migrations/2026_01_08_143558_create_farm_mail_badges.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('farm_mail_badges', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade')->comment('ユーザーID');
+            $table->foreignId('farm_id')->constrained()->onDelete('cascade')->comment('ファームID');
+
+            //送信状態
+            $table->timestamp('send_at')->nullable()->comment('送信時間');
+            $table->timestamp('failed_at')->nullable()->comment('失敗時間');
+            $table->text('last_error')->nullable()->comment('メール送信失敗時のエラーメッセージ');
+
+            $table->timestamps();
+
+            $table->unique(['user_id', 'farm_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('farm_mail_badges');
+    }
+};

--- a/src/database/migrations/2026_01_10_181226_create_review_mail_badges_table.php
+++ b/src/database/migrations/2026_01_10_181226_create_review_mail_badges_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('review_mail_badges', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade')->comment('コメントが届いたレビューを作成したユーザーID');
+            $table->foreignId('review_id')->constrained()->onDelete('cascade')->comment('コメントが届いたレビューID');
+
+            // 送信状態
+            $table->timestamp('sent_at')->nullable()->comment('送信時間');
+            $table->timestamp('failed_at')->nullable()->comment('失敗時間');
+            $table->text('last_error')->nullable()->comment('送信失敗のエラー内容');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'review_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('review_mail_badges');
+    }
+};

--- a/src/database/migrations/2026_01_13_114431_add_lat_lng_to_farms_table.php
+++ b/src/database/migrations/2026_01_13_114431_add_lat_lng_to_farms_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('farms', function (Blueprint $table) {
+            $table->decimal('latitude', 10, 7)->nullable()->after('postcode')->comment('緯度');
+            $table->decimal('longitude', 10, 7)->nullable()->after('latitude')->comment('軽度');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('farms', function (Blueprint $table) {
+            $table->dropColumn(['latitude', 'longitude']);
+        });
+    }
+};

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -30,7 +30,7 @@
         <env name="DB_USERNAME" value="test_user"/>
         <env name="DB_PASSWORD" value="test"/> -->
         <env name="MAIL_MAILER" value="array"/>
-        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="QUEUE_CONNECTION" value="database"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="TELESCOPE_ENABLED" value="false"/>

--- a/src/resources/js/Components/Organisms/FarmList.tsx
+++ b/src/resources/js/Components/Organisms/FarmList.tsx
@@ -30,11 +30,44 @@ type Farm = {
     postcode: string;
     state: State;
     crops: Crops[];
+    latitude?: number | string | null;
+    longitude?: number | string | null;
 };
 
 type FarmListProps = {
     farm: Farm;
 }
+
+const FarmMap = ({ farm }: { farm: Farm }) => {
+    // ① 緯度経度があるか確認（あるなら座標優先）
+    const hasLatLng = farm.latitude != null && farm.longitude != null;
+
+    // ② 住所を組み立て（lat/lngがない時の保険）
+    const address = `${farm.street_address},${farm.suburb},${farm.state?.name ?? ""}, ${farm.postcode}, Australia`;
+
+
+    // ③ iframeのsrcを作る（lat/lngがあればそれ、なければ住所）
+    const src = hasLatLng
+        ? `https://www.google.com/maps?q=${farm.latitude},${farm.longitude}&z=15&output=embed`
+        : `https://www.google.com/maps?q=${encodeURIComponent(address)}&z=15&output=embed`;
+
+    // ④ 住所も緯度経度も無いなら何も表示しない（安全）
+    if (!hasLatLng && !farm.street_address) return null;
+
+    return (
+        <>
+            <Box mt={4}>
+                <Text mb={2} fontWeight={"bold"}>地図</Text>
+                <Box borderRadius={"md"} overflow={"hidden"}>
+                    <iframe src={src} title="farm_map" width={"100%"} height={"320"} style={{border: 0}} loading="lazy" />
+                </Box>
+            </Box>
+        </>
+
+    )
+
+}
+
 
 const FarmList = ({ farm }: FarmListProps) => {
     return (
@@ -71,6 +104,7 @@ const FarmList = ({ farm }: FarmListProps) => {
                 <Text mb={1}>説明</Text>
                 <FarmDescription description={farm.description} />
 
+                    <FarmMap farm={farm} />
 
 
 

--- a/src/resources/js/Components/Organisms/FarmList.tsx
+++ b/src/resources/js/Components/Organisms/FarmList.tsx
@@ -70,6 +70,10 @@ const FarmList = ({ farm }: FarmListProps) => {
                 </HStack>
                 <Text mb={1}>説明</Text>
                 <FarmDescription description={farm.description} />
+
+
+
+
             </Box>
         </Box>
     );

--- a/src/resources/views/emails/farms/created.blade.php
+++ b/src/resources/views/emails/farms/created.blade.php
@@ -1,0 +1,19 @@
+<x-mail::message>
+# Introduction
+
+<p>新しいファームが作成されましたのでお知らせいたします。</p>
+<p>{{$farm->name}}</p>
+<div class="flex">
+    <p>{{$farm->street_address}}</p>
+    <p>{{$farm->suburb}}</p>
+    <p>{{$farm->state_id}}</p>
+    <p>{{$farm->postcode}}</p>
+</div>
+
+<x-mail::button :url="route('farm.detail', ['id' => $farm->id])">
+ファームを見る
+</x-mail::button>
+
+Thanks,<br>
+{{ config('app.name') }}
+</x-mail::message>

--- a/src/resources/views/emails/reviews/reviewCreated.blade.php
+++ b/src/resources/views/emails/reviews/reviewCreated.blade.php
@@ -1,0 +1,12 @@
+<x-mail::message>
+    # Introduction
+
+    <p>あなたの{{ $review->farm->name }}にしたレビューに対してコメントが届きましたのでお知らせいたします。</p>
+
+    <x-mail::button :url="route('farm.detail', ['id' => $review->farm->id])">
+        レビューコメントを見る
+    </x-mail::button>
+
+    Thanks,<br>
+    {{ config('app.name') }}
+</x-mail::message>

--- a/src/tests/Feature/Badges/FarmMailBadgeTest.php
+++ b/src/tests/Feature/Badges/FarmMailBadgeTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\Badges;
+
+use App\Events\FarmCreated;
+use App\Jobs\SendFarmCreatedEmailJob;
+use App\Mail\FarmCreatedMail;
+use App\Models\Crop;
+use App\Models\Farm;
+use App\Models\FarmMailBadge;
+use App\Models\State;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class FarmMailBadgeTest extends TestCase
+{
+
+    use refreshDatabase;
+
+    /**
+     * A basic feature test example.
+     */
+    public function testFarmMailUntilDispatch(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        Crop::factory()->create();
+        $state = State::factory()->create();
+
+        $farm = Farm::factory()->for($user, 'user')->for($state, 'state')->create();
+
+        $this->assertDatabaseHas('farm_mail_badges', [
+            'farm_id' => $farm->id,
+            'user_id' => $user->id,
+        ]);
+
+        Queue::assertPushedOn('mail', SendFarmCreatedEmailJob::class, function ($job) {
+            return is_int($job->badgeId);
+        });
+    }
+
+
+    public function testFarmMailFromDispatchSuccess(): void
+    {
+        Mail::fake();
+
+        $testTime = Carbon::parse('2026-01-01 10:00:00');
+        Carbon::setTestNow($testTime);
+
+        $user = User::factory()->create(['email' => 'test@example.com']);
+        Crop::factory()->create();
+        $state = State::factory()->create();
+
+        $farm = Farm::factory()->for($user, 'user')->for($state, 'state')->createQuietly();
+
+        $badge = FarmMailBadge::create([
+            'user_id' => $user->id,
+            'farm_id' => $farm->id,
+        ]);
+
+        SendFarmCreatedEmailJob::dispatch($badge->id)->onQueue('mail');
+        $this->artisan('queue:work --once --queue=mail');
+
+        $this->assertDatabaseHas('farm_mail_badges', [
+            'send_at'    => $testTime->format('Y-m-d H:i'),
+            'failed_at'  => null,
+            'last_error' => null,
+        ]);
+
+
+        Mail::assertSent(FarmCreatedMail::class, 'test@example.com');
+    }
+
+
+    public function testFarmMailFromDispatchFail(): void
+    {
+        $testTime = Carbon::parse('2026-01-01 10:00:00');
+        Carbon::setTestNow($testTime);
+
+        $user = User::factory()->create(['email' => 'test@example.com']);
+        Crop::factory()->create();
+        $state = State::factory()->create();
+
+        $farm = Farm::factory()->for($user, 'user')->for($state, 'state')->createQuietly();
+
+        $badge = FarmMailBadge::create([
+            'user_id' => $user->id,
+            'farm_id' => $farm->id,
+            'send_at' => null,
+            'failed_at' => null,
+            'last_error' => null,
+        ]);
+
+
+        SendFarmCreatedEmailJob::dispatch($badge->id)->onQueue('mail');
+        Mail::shouldReceive('to')->andThrow(new \Exception('Mail failure'));
+        $this->artisan('queue:work --once --queue=mail');
+        $this->artisan('queue:work --once --queue=mail');
+        $this->artisan('queue:work --once --queue=mail');
+
+
+        $this->assertDatabaseHas('farm_mail_badges', [
+            'id'         => $badge->id,
+            'send_at'    => null,
+            'failed_at'  => $testTime->format('Y-m-d H:i:s'),
+            'last_error'  => 'Mail failure',
+        ]);
+
+        Mail::shouldReceive('send')->never();
+    }
+}

--- a/src/tests/Feature/Badges/FarmMailBadgeTest.php
+++ b/src/tests/Feature/Badges/FarmMailBadgeTest.php
@@ -107,7 +107,7 @@ class FarmMailBadgeTest extends TestCase
 
         $this->assertDatabaseHas('farm_mail_badges', [
             'id'         => $badge->id,
-            'send_at'    => null,
+            'sent_at'    => null,
             'failed_at'  => $testTime->format('Y-m-d H:i:s'),
             'last_error'  => 'Mail failure',
         ]);

--- a/src/tests/Feature/Badges/ReviewMailBadgeTest.php
+++ b/src/tests/Feature/Badges/ReviewMailBadgeTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Feature\Badges;
+
+use App\Events\ReviewCommentCreated;
+use App\Jobs\SendReviewCreatedEmailJob;
+use App\Mail\ReviewCreateMail;
+use App\Models\ApplicationMethod;
+use App\Models\Farm;
+use App\Models\Review;
+use App\Models\ReviewComments;
+use App\Models\ReviewMailBadge;
+use App\Models\State;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class ReviewMailBadgeTest extends TestCase
+{
+    /**
+     * コメントを受けてからjobまでの動きをテスト
+     */
+    public function testReviewBadgeUntilListener(): void
+    {
+        Queue::fake();
+
+        $user        = User::factory()->create();
+        $commentUser = User::factory()->create();
+        $state       = State::factory()->create();
+        $farm        = Farm::factory()->for($user, 'user')->for($state, 'state')->create();
+        $method      = ApplicationMethod::factory()->create();
+        $review      = Review::factory()->for($method, 'applicationMethod')->for($user, 'reviewUser')->for($farm, 'farm')->create();
+        ReviewComments::create([
+            'review_id' => $review->id,
+            'user_id'   => $commentUser->id,
+            'comment'   => 'テストコメント',
+        ]);
+
+        $this->assertDatabaseHas('review_comments', [
+            'review_id' => $review->id,
+            'user_id'   => $commentUser->id,
+            'comment'   => 'テストコメント',
+        ]);
+
+        $badge = ReviewMailBadge::where('review_id', $review->id)->firstOrFail();
+
+        $this->assertDatabaseHas('development.review_mail_badges', [
+            'user_id'   => $user->id,
+            'review_id' => $review->id,
+        ]);
+
+        Queue::assertPushedOn('mail', SendReviewCreatedEmailJob::class, function ($job) use ($badge) {
+            return $job->badgeId === $badge->id;
+        });
+    }
+
+    /**
+     * jobからメール発送の動きをテスト
+     */
+    public function testReviewBadgeFromJob(): void
+    {
+        Mail::fake();
+
+        $setTime    = Carbon::parse('2026-01-01 10:00:00');
+        Carbon::setTestNow($setTime);
+
+        $user        = User::factory()->create();
+        $commentUser = User::factory()->create();
+        $state       = State::factory()->create();
+        $farm        = Farm::factory()->for($user, 'user')->for($state, 'state')->create();
+        $method      = ApplicationMethod::factory()->create();
+        $review      = Review::factory()->for($method, 'applicationMethod')->for($user, 'reviewUser')->for($farm, 'farm')->create();
+        ReviewComments::createQuietly([
+            'review_id' => $review->id,
+            'user_id'   => $commentUser->id,
+            'comment'   => 'テストコメント',
+        ]);
+
+        $this->assertDatabaseHas('review_comments', [
+            'review_id' => $review->id,
+            'user_id'   => $commentUser->id,
+            'comment'   => 'テストコメント',
+        ]);
+
+        $badge = $badge = ReviewMailBadge::create([
+            'user_id'   => $user->id,
+            'review_id' => $review->id,
+        ]);
+
+        (new SendReviewCreatedEmailJob($badge->id))->handle();
+
+        Mail::assertSent(function (ReviewCreateMail $mail) use ($badge) {
+            return $mail->hasTo($badge->user->email)
+                && $mail->review->is($badge->review);
+        });
+
+        $this->assertDatabaseHas('review_mail_badges', [
+            'id'         => $badge->id,
+            'sent_at'    => $setTime,
+            'failed_at'  => null,
+            'last_error' => null,
+        ]);
+    }
+
+    /**
+     * jobからメール発送の動きをテスト(失敗)
+     */
+    public function testReviewBadgeFromJobFailed(): void
+    {
+        Mail::fake();
+
+        $setTime    = Carbon::parse('2026-01-01 10:00:00');
+        Carbon::setTestNow($setTime);
+
+        $user        = User::factory()->create();
+        $commentUser = User::factory()->create();
+        $state       = State::factory()->create();
+        $farm        = Farm::factory()->for($user, 'user')->for($state, 'state')->create();
+        $method      = ApplicationMethod::factory()->create();
+        $review      = Review::factory()->for($method, 'applicationMethod')->for($user, 'reviewUser')->for($farm, 'farm')->create();
+        ReviewComments::createQuietly([
+            'review_id' => $review->id,
+            'user_id'   => $commentUser->id,
+            'comment'   => 'テストコメント',
+        ]);
+
+        $this->assertDatabaseHas('review_comments', [
+            'review_id' => $review->id,
+            'user_id'   => $commentUser->id,
+            'comment'   => 'テストコメント',
+        ]);
+
+        $badge = $badge = ReviewMailBadge::create([
+            'user_id'   => $user->id,
+            'review_id' => $review->id,
+        ]);
+
+        $job   = (new SendReviewCreatedEmailJob($badge->id));
+        $error = new \Exception('Mail Failure');
+        $job->failed($error);
+
+        $this->assertDatabaseHas('review_mail_badges', [
+            'id'         => $badge->id,
+            'sent_at'    => null,
+            'failed_at'  => $setTime,
+            'last_error'  => 'Mail failure',
+        ]);
+    }
+}

--- a/src/tests/Feature/GoogleApiTest.php
+++ b/src/tests/Feature/GoogleApiTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Crop;
+use App\Models\Farm;
+use App\Models\State;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class GoogleApiTest extends TestCase
+{
+
+    use RefreshDatabase;
+    /**
+     * A basic feature test example.
+     */
+    public function testGoogleApi(): void
+    {
+        Http::fake([
+            'https://maps.googleapis.com/maps/api/geocode/json*' => Http::response([
+                'status' => 'OK',
+                'results' => [
+                    [
+                        'geometry' => [
+                            'location' => [
+                                'lat' => -27.4705,
+                                'lng' => 153.0260,
+                            ],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        config()->set('services.google_map.key', 'test-key');
+
+        $user = User::factory()->create();
+        Crop::factory()->create();
+        $state = State::create([
+            'name' => 'QLD',
+        ]);
+
+        $farm = Farm::factory()->for($user, 'user')->for($state, 'state')->create();
+
+        $farm->update([
+            'street_address' => '66 Lake Clarendon Way',
+            'suburb'         => 'Lake Clarendon',
+            'postcode'       => '4343',
+        ]);
+
+        $this->assertNotEmpty($farm->fullAddress());
+
+        $farm->refresh();
+
+        $this->assertDatabaseHas('farms', [
+            'street_address' => '66 Lake Clarendon Way',
+            'suburb'         => 'Lake Clarendon',
+            'postcode'       => '4343',
+        ]);
+
+        $this->assertEquals(-27.4705, $farm->latitude, '', 0.000001);
+        $this->assertEquals(153.0260, $farm->longitude, '', 0.000001);
+
+        Http::assertSent(function ($request) {
+            return str_starts_with($request->url(), 'https://maps.googleapis.com/maps/api/geocode/json')
+                && isset($request['address'])
+                && isset($request['key']);
+        });
+    }
+}


### PR DESCRIPTION
# Google Map表示：備忘録
## farms_tableにカラム(lantitude, langitude)追加
php artisan make:migrate add_lat_lng_to_farms_table

```
$table->decimal('laititude', 10, 7)->nullable()->after('postcode')->comment('緯度');
$table->decimal('langitude', 10 ,7)->nullable()->after('lantitude')->comment('経度');
```

## .env
外部キーを保存
`GOOGLE_MAPS_API_KEY=`

##config/services
config/servicesは、このアプリが使っている外部サービスの名簿
google apiキーを登録

```
    'google_maps' => [
        'key' => env('GOOGLE_MAPS_API_KEY'),
    ],
```

## Farmモデル
イベント駆動(Farmの登録や更新)があった際に、処理が始まる。
Farmの住所に関連するカラムキーを配列で用意する。
collectでコレクションにする。
containは、コレクションの中に 条件に一致するものが1つでもあるかを判定します。1つでもあればtrueを返す。
wasChanged() は、データベースに保存（update）された直後に、「その属性が変更されたか」をチェックする関数です。
$farm->wasChanged('street_address'): street_address が変更されていれば true を返します。
整えたアドレスをサービスに渡して、返り値を受け取る。
farms_tableのlantitudeとlangitudeに値を保存する。
forceFill()は、$fillableで指定していなくともテーブルに値を保存することができる。
validationをしなくてても安全な値に利用する。

```
public function fullAddress(): string
{
  $stateName = $this->state?->name ??  '';

  $parts = array_filter([
    $this->street_address,
    $this->suburb,
    $stateName,
    $this->postcode,
    'Australia',
], fn($part) => filled($part));

  return implode(',', $parts);
}

protected static function booted()
{
  static::saved(function(Farm $farm){
    $addressFields = ['street_address', 'suburb', 'state_id', 'postcode'];

    $changed = collect($addressFields)->contains(fn($part) => $farm->wasChanged($part));
    if (!$changed) return;

    $adress = $farm->fullAddress();
    if (blank($address)) return;

    $geo = app(GeocodingService::class)->geocode($address);
    if (!$geo) return;

    $farm->forceFill([
    'lantitude'  => $geo['lat'],
    'langitude' => $geo['lng'],
    ])->saveQuietly();
  });
}
```

## サービス（google apiへリクエストとレスポンス）
モデルから文字列（フルアドレス）を受けとり、Config/Servicesからgoogle apiキーを取得する。
Http::getの第一引数にURL、第二引数にapiキーを住所を渡す。
`$res->json()`にて、レスポンスを取得
` $data['results'][0]['geometry']['location']`に緯度と軽度がある。
それを取り出してモデルに返却

```
public function geocode(string $address): ?array
{
$key = config('services.google_map.key');

$res = Http::get('maps.googleapis.com/maps/api/geocode/json', [
  'address' => $address,
  'key'         => $key, 
]);
if(!$res->ok) return null;

$data = $res->json();
if(($data['status'] ?? '') !== 'OK') return null;

$loc = $data['results'][0]['geometry']['location'] ??  null;
if (!$loc) return null;

return ['lat' => $loc['lat'], 'lng' => $loc['lng']];
}
```

## テスト

```
Http::fale('maps.googleapis.com/maps/api/geocode/json* => Http::response([
  'status' => 'ok',
    'results' => [
    [
       'geometry' => [
          'location' => [
            'lat'  => -27.4705,
            'log' => 153.0260,
          ],
        ],
    ],
],
], 200));

config()->set('services.google_map.key', 'test-key');

Http::assertSent(function ($request){
  return str_starts_with('maps.googleapis.com/maps/api/geocode/json')
       && isset($request['address'])
       && isset($request['key'])
});;
```

# メール配信停止：備忘録

## users_tableにカラム(receive_farm_created_email)追加
配信希望はtrue、停止はfalse
`$table->boolean('receive_farm_created_email')->default(true)->after('email');`

## ルーティング
middleware('signed')は、Laravelが用意してくれているミドルウェアで、署名付きURLかを確認して問題なければ開ける。
URL::temporarySignedRoute()が、署名付きURLをつける。
2つセットで作成する。

```
Route::get('/unsubscribe/farm-created', [UnsubscribeController::class, 'farmCreated'])
    ->middleware('signed')->name('unsubscribe.farmCreated');
```

## ジョブ
配信停止をしたユーザーを取得するために引数を1つ増やしてMailableに渡す。

```
Mail::to($badge->user->email)->send(new FarmCreatedMail($badge->farm));
↓
Mail::to($badge->user->email)->send(new FarmCreatedMail($badge->farm, $badge->user));
```

## Mailable
URL::temporarySignedRoute()をここで設定して、クエリパラメータを変数に入れる。
withで渡すことができる。
この場合は、クエリパラメータになる。`URL.../farm-created?expires=1771688077&user=2&signature=b1c8b6`
クエリパラメータとは、キー名=値
この場合、$request->query('user')で取得できる。
ルートパラメータとは、ルーディングの際に、{user}と入れる。結果、`URL.../farm-created/2?expires=1771688077&signature=b1c8b6`となり「2」がユーザーidとなる。
キー名は変わらずuserとなる。ルートパラメータは、URLにキー名は表示されない。
取得する際は、`$request->route('user')`で取得できる。

```
Route::get('/unsubscribe/farm-created/{user}', [UnsubscribeController::class, 'farmCreated'])
    ->middleware('signed')->name('unsubscribe.farmCreated');
```

```
public function __construct(
public Farm $farm,
public User $toUser
)

public function content()
{
  $unsubscribeUrl = URL::temporarySignedRoute(
    'unsubscribe.farmCreated',
     now()->addDays(30),
     ['user' => $this->toUser->id],
  );
  
  return new Content(
    markdown: 'emails.farms.created',
    with: ['unsubscribeUrl' => $unsubscribeUrl],
  ) ;
)
```

## コントローラー
新規ファーム作成によって送られたメールの配信停止をクリックすると
自動的に配信ていしのfalseが登録されて、配信停止されましたというメッセージが表示される。

```
public function farmCreated(Request $request)
{
  $userId = $request->query('user');
  
  $user = User::findOrFail($userId);
  
  $user->update([
    'receive_farm_created_email' => false,
  ]);
  
  return view('unsubscribe.farmCreated', [
            'message' => '新規ファーム作成メールの配信を停止しました。',
        ]);
}
```

## ビュー

farmCreated.blade.php
```
<!doctype html>
<html lang="ja">
<head>
  <meta charset="utf-8">
  <title>配信停止</title>
</head>
<body style="font-family: sans-serif; padding: 24px;">
  <h1>配信停止完了</h1>
  <p>{{ $message }}</p>
</body>
</html>
```
